### PR TITLE
Upload coverage details to separate artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,12 @@ jobs:
       run: dotnet build --configuration Debug
     - name: Test with dotnet
       run: dotnet test /p:CollectCoverage=true /p:CoverletOutput='./coverage/'
-      
+    - name: Upload coverage details
+      uses: actions/upload-artifact@v1
+      with:
+        name: coverage-ubuntu
+        path: ./Fingerprinty.Test.NetCore/coverage
+
   build-windows:
 
     runs-on: windows-latest
@@ -37,3 +42,8 @@ jobs:
       run: dotnet build --configuration Debug
     - name: Test with dotnet
       run: dotnet test /p:CollectCoverage=true /p:CoverletOutput='./coverage/'
+    - name: Upload coverage details
+      uses: actions/upload-artifact@v1
+      with:
+        name: coverage-windows
+        path: ./Fingerprinty.Test.NetCore/coverage


### PR DESCRIPTION
Related to #7. Having the results as artifacts should enable later parsing and visualization.